### PR TITLE
Scheduling multiple userspace commands and executing at init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ debug:
 	mkdir -p build/debug && \
 		cd build/debug && \
 		cmake ../ && \
-		make --jobs
+		make --jobs 4
 
 release: debug
 	# apt-get install -y binutils
@@ -23,7 +23,7 @@ dev:
 	mkdir -p build/dev && \
 		cd build/dev && \
 		cmake -D BUILD_TYPE=Development ../ && \
-		make --jobs
+		make --jobs 4
 
 clean: clean-bin clean-debug clean-dev clean-debian
 

--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required(VERSION 3.1)
 
 project(ovlsnap)
 
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/../bin)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/../bin")
 set(SRC "${CMAKE_CURRENT_LIST_DIR}/../src")
 include_directories("${CMAKE_CURRENT_LIST_DIR}/../include")
 
@@ -22,22 +22,39 @@ if("${BUILD_TYPE}" STREQUAL "Development")
     set(CMAKE_CXX_FLAGS "-D_DEBUG_")
 endif()
 
-# TODO: compile this lib to be static not dynamic.
 find_library(LIBDOCOPT_STATIC libdocopt.a)
+# TODO: compile this lib to be static not dynamic.
 find_library(LIBPARSON_STATIC parson)
 
 add_executable(ovlsnap-init "${SRC}/ovlsnap-init.cpp")
 target_sources(ovlsnap-init PUBLIC
     "${SRC}/AppState.cpp"
+    "${SRC}/CommandHandler.cpp"
+    "${SRC}/Commands/CommandFactory.cpp"
+    "${SRC}/Commands/EnableCommand.cpp"
+    "${SRC}/Commands/CreateCommand.cpp"
+    "${SRC}/Commands/DropCommand.cpp"
+    "${SRC}/Commands/MergeCommand.cpp"
     "${SRC}/Snapshot.cpp"
     "${SRC}/Status.cpp"
     "${SRC}/Utils.cpp")
-target_link_libraries(ovlsnap-init ${LIBPARSON_STATIC})
+target_link_libraries(ovlsnap-init
+    ${LIBPARSON_STATIC}
+)
 
 add_executable(ovlsnap "${SRC}/ovlsnap.cpp")
 target_sources(ovlsnap PUBLIC
     "${SRC}/AppState.cpp"
+    "${SRC}/CommandScheduler.cpp"
+    "${SRC}/Commands/CommandFactory.cpp"
+    "${SRC}/Commands/EnableCommand.cpp"
+    "${SRC}/Commands/CreateCommand.cpp"
+    "${SRC}/Commands/DropCommand.cpp"
+    "${SRC}/Commands/MergeCommand.cpp"
     "${SRC}/Snapshot.cpp"
     "${SRC}/Status.cpp"
     "${SRC}/Utils.cpp")
-target_link_libraries(ovlsnap ${LIBPARSON_STATIC} ${LIBDOCOPT_STATIC})
+target_link_libraries(ovlsnap
+    ${LIBPARSON_STATIC}
+    ${LIBDOCOPT_STATIC}
+)

--- a/conf/overlay-snapshots/ovlsnap_status.json
+++ b/conf/overlay-snapshots/ovlsnap_status.json
@@ -1,6 +1,6 @@
 {
     "state": 0,
-    "state_params": [],
+    "scheduled_commands": [],
     "snapshots": [],
     "error_code": 0
 }

--- a/include/AppState.h
+++ b/include/AppState.h
@@ -17,16 +17,11 @@
 class AppState {
 
     public:  // Enums.
-        // NOTE: Do not change the order of the states below! The status file
-        // contains the current state which is a state defined below.
+        // WARNING: Do not change the order of the states below! The status
+        // file contains the current state which is a state defined below.
         enum State {
             /* 0 */ DISABLED,
-            /* 1 */ ENABLED,
-            /* 2 */ CREATE,
-            /* 3 */ DROP,
-            /* 4 */ MERGE,
-            /* 5 */ DROP_CREATE,
-            /* 6 */ MERGE_CREATE
+            /* 1 */ ENABLED
         };
 
     public:  // Methods.
@@ -37,8 +32,8 @@ class AppState {
         AppState::State getState();
 
     private:  // Members.
-        JSON_Object* statusData;
+        JSON_Object* statusData = NULL;
         AppState::State state;
 };
 
-#endif
+#endif  // __OVLSNAP_APP_STATE_H__

--- a/include/CommandHandler.h
+++ b/include/CommandHandler.h
@@ -1,0 +1,36 @@
+/**
+ * CommandHandler.h
+ *
+ * Copyright (C) 2018 Kano Computing Ltd.
+ * License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+ *
+ * TODO: Description
+ */
+
+
+#ifndef __OVLSNAP_COMMAND_HANDLER_H__
+#define __OVLSNAP_COMMAND_HANDLER_H__
+
+#include <parson/parson.h>
+
+#include "AppState.h"
+#include "Commands/CommandFactory.h"
+#include "Commands/ICommand.h"
+#include "Snapshot.h"
+
+
+class CommandHandler {
+
+    public:  // Methods.
+        CommandHandler(JSON_Object* statusLoadedData);
+        ~CommandHandler();
+
+        void executeAll(AppState* state, Snapshot* snapshot);
+
+    private:  // Members.
+        JSON_Object* statusData = NULL;
+        JSON_Array* scheduledCommands = NULL;
+        CommandFactory commandFactory;
+};
+
+#endif  // __OVLSNAP_COMMAND_HANDLER_H__

--- a/include/CommandScheduler.h
+++ b/include/CommandScheduler.h
@@ -1,0 +1,36 @@
+/**
+ * CommandScheduler.h
+ *
+ * Copyright (C) 2018 Kano Computing Ltd.
+ * License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+ *
+ * TODO: Description
+ */
+
+
+#ifndef __OVLSNAP_COMMAND_SCHEDULER_H__
+#define __OVLSNAP_COMMAND_SCHEDULER_H__
+
+#include <parson/parson.h>
+
+#include "Commands/ICommand.h"
+#include "Commands/CommandFactory.h"
+
+
+class CommandScheduler {
+
+    public:  // Methods.
+        CommandScheduler(JSON_Object* statusLoadedData);
+        ~CommandScheduler();
+
+        void schedule(ICommand& command);
+        void clear();
+        void status();
+
+    private:  // Members.
+        JSON_Object* statusData = NULL;
+        JSON_Array* scheduledCommands = NULL;
+        CommandFactory commandFactory;
+};
+
+#endif  // __OVLSNAP_COMMAND_SCHEDULER_H__

--- a/include/Commands/CommandFactory.h
+++ b/include/Commands/CommandFactory.h
@@ -1,0 +1,49 @@
+/**
+ * CommandFactory.h
+ *
+ * Copyright (C) 2018 Kano Computing Ltd.
+ * License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+ *
+ * TODO: Description
+ */
+
+
+#ifndef __OVLSNAP_COMMAND_FACTORY_H__
+#define __OVLSNAP_COMMAND_FACTORY_H__
+
+#include <parson/parson.h>
+
+#include "Commands/ICommand.h"
+#include "Commands/EnableCommand.h"
+#include "Commands/CreateCommand.h"
+#include "Commands/DropCommand.h"
+#include "Commands/MergeCommand.h"
+
+
+class CommandFactory {
+
+    public:  // Enums.
+        // WARNING: Do not change the order of the values below! The status
+        // file may contain commands with their types already defined.
+        enum CommandType {
+            /* 0 */ ENABLE,
+            /* 1 */ CREATE,
+            /* 2 */ DROP,
+            /* 3 */ MERGE
+        };
+
+    public:  // Methods.
+        CommandFactory();
+        ~CommandFactory();
+
+        ICommand* getCommandByData(JSON_Value* serialisedData);
+        ICommand* getCommandById(int id);
+
+    private:  // Members.
+        EnableCommand* enableCommand = NULL;
+        CreateCommand* createCommand = NULL;
+        DropCommand* dropCommand = NULL;
+        MergeCommand* mergeCommand = NULL;
+};
+
+#endif  // __OVLSNAP_COMMAND_FACTORY_H__

--- a/include/Commands/CreateCommand.h
+++ b/include/Commands/CreateCommand.h
@@ -1,0 +1,44 @@
+/**
+ * CreateCommand.h
+ *
+ * Copyright (C) 2018 Kano Computing Ltd.
+ * License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+ *
+ * TODO: Description
+ */
+
+
+#ifndef __OVLSNAP_CREATE_COMMAND_H__
+#define __OVLSNAP_CREATE_COMMAND_H__
+
+#include <string>
+
+#include <parson/parson.h>
+
+#include "AppState.h"
+#include "Commands/ICommand.h"
+#include "Snapshot.h"
+
+
+class CreateCommand: public ICommand {
+
+    public:  // Methods.
+        CreateCommand();
+        CreateCommand(std::string snapshotName);
+        ~CreateCommand();
+
+        // Implement ISerialisable:
+        bool initialise(JSON_Value* serialisedData);
+        JSON_Value* serialise();
+
+        // Implement ICommand:
+        bool execute(AppState* state, Snapshot* snapshot);
+        unsigned int getId();
+        std::string toString();
+
+    private:  // Members.
+        unsigned int id;
+        std::string snapshotName;
+};
+
+#endif  // __OVLSNAP_CREATE_COMMAND_H__

--- a/include/Commands/DropCommand.h
+++ b/include/Commands/DropCommand.h
@@ -1,0 +1,44 @@
+/**
+ * DropCommand.h
+ *
+ * Copyright (C) 2018 Kano Computing Ltd.
+ * License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+ *
+ * TODO: Description
+ */
+
+
+#ifndef __OVLSNAP_DROP_COMMAND_H__
+#define __OVLSNAP_DROP_COMMAND_H__
+
+#include <string>
+
+#include <parson/parson.h>
+
+#include "AppState.h"
+#include "Commands/ICommand.h"
+#include "Snapshot.h"
+
+
+class DropCommand: public ICommand {
+
+    public:  // Methods.
+        DropCommand();
+        DropCommand(int topMostSnapshots);
+        ~DropCommand();
+
+        // Implement ISerialisable:
+        bool initialise(JSON_Value* serialisedData);
+        JSON_Value* serialise();
+
+        // Implement ICommand:
+        bool execute(AppState* state, Snapshot* snapshot);
+        unsigned int getId();
+        std::string toString();
+
+    private:  // Members.
+        unsigned int id;
+        int topMostSnapshots;
+};
+
+#endif  // __OVLSNAP_DROP_COMMAND_H__

--- a/include/Commands/EnableCommand.h
+++ b/include/Commands/EnableCommand.h
@@ -1,0 +1,44 @@
+/**
+ * EnableCommand.h
+ *
+ * Copyright (C) 2018 Kano Computing Ltd.
+ * License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+ *
+ * TODO: Description
+ */
+
+
+#ifndef __OVLSNAP_ENABLE_COMMAND_H__
+#define __OVLSNAP_ENABLE_COMMAND_H__
+
+#include <string>
+
+#include <parson/parson.h>
+
+#include "AppState.h"
+#include "Commands/ICommand.h"
+#include "Snapshot.h"
+
+
+class EnableCommand: public ICommand {
+
+    public:  // Methods.
+        EnableCommand();
+        EnableCommand(bool isEnabled);
+        ~EnableCommand();
+
+        // Implement ISerialisable:
+        bool initialise(JSON_Value* serialisedData);
+        JSON_Value* serialise();
+
+        // Implement ICommand:
+        bool execute(AppState* state, Snapshot* snapshot);
+        unsigned int getId();
+        std::string toString();
+
+    private:  // Members.
+        unsigned int id;
+        bool isEnabled;
+};
+
+#endif  // __OVLSNAP_ENABLE_COMMAND_H__

--- a/include/Commands/ICommand.h
+++ b/include/Commands/ICommand.h
@@ -1,0 +1,31 @@
+/**
+ * ICommand.h
+ *
+ * Copyright (C) 2018 Kano Computing Ltd.
+ * License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+ *
+ * TODO: Description
+ */
+
+
+#ifndef __OVLSNAP_ICOMMAND_H__
+#define __OVLSNAP_ICOMMAND_H__
+
+#include <string>
+
+#include <parson/parson.h>
+
+#include "AppState.h"
+#include "ISerialisable.h"
+#include "Snapshot.h"
+
+
+class ICommand: public ISerialisable {
+
+    public:
+        virtual bool execute(AppState* state, Snapshot* snapshot) = 0;
+        virtual unsigned int getId() = 0;
+        virtual std::string toString() = 0;
+};
+
+#endif  // __OVLSNAP_ICOMMAND_H__

--- a/include/Commands/MergeCommand.h
+++ b/include/Commands/MergeCommand.h
@@ -1,0 +1,44 @@
+/**
+ * MergeCommand.h
+ *
+ * Copyright (C) 2018 Kano Computing Ltd.
+ * License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+ *
+ * TODO: Description
+ */
+
+
+#ifndef __OVLSNAP_MERGE_COMMAND_H__
+#define __OVLSNAP_MERGE_COMMAND_H__
+
+#include <string>
+
+#include <parson/parson.h>
+
+#include "AppState.h"
+#include "Commands/ICommand.h"
+#include "Snapshot.h"
+
+
+class MergeCommand: public ICommand {
+
+    public:  // Methods.
+        MergeCommand();
+        MergeCommand(int topMostSnapshots);
+        ~MergeCommand();
+
+        // Implement ISerialisable:
+        bool initialise(JSON_Value* serialisedData);
+        JSON_Value* serialise();
+
+        // Implement ICommand:
+        bool execute(AppState* state, Snapshot* snapshot);
+        unsigned int getId();
+        std::string toString();
+
+    private:  // Members.
+        unsigned int id;
+        int topMostSnapshots;
+};
+
+#endif  // __OVLSNAP_MERGE_COMMAND_H__

--- a/include/ISerialisable.h
+++ b/include/ISerialisable.h
@@ -1,0 +1,26 @@
+/**
+ * ISerialisable.h
+ *
+ * Copyright (C) 2018 Kano Computing Ltd.
+ * License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+ *
+ * TODO: Description
+ */
+
+
+#ifndef __OVLSNAP_ISERIALISABLE_H__
+#define __OVLSNAP_ISERIALISABLE_H__
+
+#include <string>
+
+#include <parson/parson.h>
+
+
+class ISerialisable {
+
+    public:
+        virtual bool initialise(JSON_Value* serialisedData) = 0;
+        virtual JSON_Value* serialise() = 0;
+};
+
+#endif  // __OVLSNAP_ISERIALISABLE_H__

--- a/include/Snapshot.h
+++ b/include/Snapshot.h
@@ -42,9 +42,9 @@ class Snapshot {
         std::string getRealDir();
 
     private:  // Members.
-        JSON_Object* statusData;
+        JSON_Object* statusData = NULL;
 
-        JSON_Array* snapshots;
+        JSON_Array* snapshots = NULL;
         std::string lowerDir;
         std::string upperDir;
 
@@ -86,4 +86,4 @@ class Snapshot {
         static constexpr const char* OVERLAY_MERGED_DIR = "merged";
 };
 
-#endif
+#endif  // __OVLSNAP_SNAPSHOT_H__

--- a/src/AppState.cpp
+++ b/src/AppState.cpp
@@ -17,9 +17,10 @@
 #include "Logging.h"
 
 
-AppState::AppState(JSON_Object* statusLoadedData) {
-    this->statusData = statusLoadedData;
+AppState::AppState(JSON_Object* statusLoadedData):
+    statusData(statusLoadedData) {
 
+    // TODO: Check if field is not there.
     this->state = (AppState::State)(int)json_object_get_number(
         this->statusData, "state"
     );

--- a/src/CommandHandler.cpp
+++ b/src/CommandHandler.cpp
@@ -1,0 +1,57 @@
+/**
+ * CommandHandler.cpp
+ *
+ * Copyright (C) 2018 Kano Computing Ltd.
+ * License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+ *
+ * TODO: Description
+ */
+
+
+#include <parson/parson.h>
+
+#include "AppState.h"
+#include "CommandHandler.h"
+#include "Commands/ICommand.h"
+#include "Commands/CommandFactory.h"
+#include "Logging.h"
+#include "Snapshot.h"
+
+
+CommandHandler::CommandHandler(JSON_Object* statusLoadedData):
+    statusData(statusLoadedData) {
+
+    // TODO: Check if field is not there.
+    this->scheduledCommands = json_object_get_array(
+        this->statusData, "scheduled_commands"
+    );
+}
+
+CommandHandler::~CommandHandler() {
+}
+
+void CommandHandler::executeAll(AppState* state, Snapshot* snapshot) {
+    int commandsCount = json_array_get_count(this->scheduledCommands);
+
+    ICommand* command;
+    JSON_Value* commandData;
+
+    for (int index = 0; index < commandsCount; index++) {
+        commandData = json_array_get_value(this->scheduledCommands, index);
+        command = this->commandFactory.getCommandByData(commandData);
+
+        if (command == NULL) {
+            LOG_ERROR(
+                "CommandHandler: executeAll: Scheduled command at index "
+                << index << " with body " << json_serialize_to_string(commandData)
+                << " does not contain a known id field!"
+            );
+            continue;
+        }
+
+        command->initialise(commandData);
+        command->execute(state, snapshot);
+    }
+
+    json_array_clear(this->scheduledCommands);
+}

--- a/src/CommandScheduler.cpp
+++ b/src/CommandScheduler.cpp
@@ -1,0 +1,85 @@
+/**
+ * CommandScheduler.cpp
+ *
+ * Copyright (C) 2018 Kano Computing Ltd.
+ * License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+ *
+ * TODO: Description
+ */
+
+
+#include <parson/parson.h>
+
+#include "CommandScheduler.h"
+#include "Commands/ICommand.h"
+#include "Commands/CommandFactory.h"
+#include "Logging.h"
+
+
+CommandScheduler::CommandScheduler(JSON_Object* statusLoadedData):
+    statusData(statusLoadedData) {
+
+    // TODO: Check if field is not there.
+    this->scheduledCommands = json_object_get_array(
+        this->statusData, "scheduled_commands"
+    );
+}
+
+CommandScheduler::~CommandScheduler() {
+}
+
+void CommandScheduler::schedule(ICommand& command) {
+    // TODO: Handle edge-cases for various types of commands:
+    switch(command.getId()) {
+        case CommandFactory::ENABLE:
+            //  * EnableCommand: remove duplicates
+            break;
+
+        case CommandFactory::CREATE:
+            //  * CreateCommand: check if it already exists
+            break;
+
+        case CommandFactory::DROP:
+            //  * DropCommand: resize to max num of snapshots, merge consecutives
+            break;
+
+        case CommandFactory::MERGE:
+            //  * MergeCommnad: resize to max num of snapshots, merge consecutives
+            break;
+    }
+
+    json_array_append_value(this->scheduledCommands, command.serialise());
+}
+
+void CommandScheduler::clear() {
+    json_array_clear(this->scheduledCommands);
+}
+
+void CommandScheduler::status() {
+    int commandsCount = json_array_get_count(this->scheduledCommands);
+    if (commandsCount == 0) {
+        return;
+    }
+
+    std::cout << "Scheduled commands after reboot are:\n";
+
+    ICommand* command;
+    JSON_Value* commandData;
+
+    for (int index = 0; index < commandsCount; index++) {
+        commandData = json_array_get_value(this->scheduledCommands, index);
+        command = this->commandFactory.getCommandByData(commandData);
+
+        if (command == NULL) {
+            LOG_ERROR(
+                "CommandScheduler: status: Scheduled command at index "
+                << index << " with body " << json_serialize_to_string(commandData)
+                << " does not contain a known id field!"
+            );
+            continue;
+        }
+
+        command->initialise(commandData);
+        std::cout << "  " << command->toString() << "\n";
+    }
+}

--- a/src/Commands/CommandFactory.cpp
+++ b/src/Commands/CommandFactory.cpp
@@ -1,0 +1,88 @@
+/**
+ * CommandFactory.h
+ *
+ * Copyright (C) 2018 Kano Computing Ltd.
+ * License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+ *
+ * TODO: Description
+ */
+
+
+#include <parson/parson.h>
+
+#include "Commands/CommandFactory.h"
+#include "Commands/ICommand.h"
+#include "Commands/EnableCommand.h"
+#include "Commands/CreateCommand.h"
+#include "Commands/DropCommand.h"
+#include "Commands/MergeCommand.h"
+#include "Logging.h"
+
+
+CommandFactory::CommandFactory() {
+}
+
+CommandFactory::~CommandFactory() {
+    if (this->enableCommand != NULL) {
+        delete this->enableCommand;
+    }
+    if (this->createCommand != NULL) {
+        delete this->createCommand;
+    }
+    if (this->dropCommand != NULL) {
+        delete this->dropCommand;
+    }
+    if (this->mergeCommand != NULL) {
+        delete this->mergeCommand;
+    }
+}
+
+ICommand* CommandFactory::getCommandByData(JSON_Value* serialisedData) {
+    JSON_Object* jsonObject = json_value_get_object(serialisedData);
+
+    // TODO: Update the Kano libparson to get these:
+    // if (!json_object_has_value_of_type(jsonObject, "id", JSONNumber)) {
+    //     LOG_ERROR(
+    //         "CommandScheduler: status: Scheduled command at index "
+    //         << index << " with body " << json_serialize_to_string(serialisedData)
+    //         << " does not contain and id field!"
+    //     );
+    //     return NULL;
+    // }
+
+    int id = json_object_get_number(jsonObject, "id");
+    return this->getCommandById(id);
+}
+
+ICommand* CommandFactory::getCommandById(int id) {
+    switch (id) {
+        case CommandFactory::ENABLE:
+            if (this->enableCommand == NULL) {
+                this->enableCommand = new EnableCommand();
+            }
+            LOG_DEBUG("CommandFactory: getCommandById: command is EnableCommand");
+            return this->enableCommand;
+
+        case CommandFactory::CREATE:
+            if (this->createCommand == NULL) {
+                this->createCommand = new CreateCommand();
+            }
+            LOG_DEBUG("CommandFactory: getCommandById: command is CreateCommand");
+            return this->createCommand;
+
+        case CommandFactory::DROP:
+            if (this->dropCommand == NULL) {
+                this->dropCommand = new DropCommand();
+            }
+            LOG_DEBUG("CommandFactory: getCommandById: command is DropCommand");
+            return this->dropCommand;
+
+        case CommandFactory::MERGE:
+            if (this->mergeCommand == NULL) {
+                this->mergeCommand = new MergeCommand();
+            }
+            LOG_DEBUG("CommandFactory: getCommandById: command is MergeCommand");
+            return this->mergeCommand;
+    }
+    return NULL;
+}

--- a/src/Commands/CreateCommand.cpp
+++ b/src/Commands/CreateCommand.cpp
@@ -1,0 +1,83 @@
+/**
+ * CreateCommand.cpp
+ *
+ * Copyright (C) 2018 Kano Computing Ltd.
+ * License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+ *
+ * TODO: Description
+ */
+
+
+#include <string>
+#include <sstream>
+
+#include <parson/parson.h>
+
+#include "Commands/CommandFactory.h"
+#include "Commands/CreateCommand.h"
+#include "Commands/ICommand.h"
+#include "Logging.h"
+#include "Snapshot.h"
+
+
+CreateCommand::CreateCommand():
+    CreateCommand("") {
+}
+
+CreateCommand::CreateCommand(std::string snapshotName):
+    id(CommandFactory::CREATE),
+    snapshotName(snapshotName) {
+
+    if (this->snapshotName.empty()) {
+        // TODO: Explode.
+    }
+
+    LOG_DEBUG("CreateCommand: constructor called");
+}
+
+CreateCommand::~CreateCommand() {
+}
+
+bool CreateCommand::initialise(JSON_Value* serialisedData) {
+    JSON_Object* jsonObject = json_value_get_object(serialisedData);
+
+    // TODO: Update the Kano libparson to get these:
+    // if (!json_object_has_value_of_type(jsonObject, "id", JSONNumber)) {
+    //     return false;
+    // }
+    // if (json_object_get_number(jsonObject, "id") != ICommand::CREATE) {
+    //     return false;
+    // }
+    // if (!json_object_has_value_of_type(jsonObject, "snapshot_name", JSONString)) {
+    //     return false;
+    // }
+
+    this->snapshotName = json_object_get_string(jsonObject, "snapshot_name");
+}
+
+JSON_Value* CreateCommand::serialise() {
+    JSON_Value* root = json_value_init_object();
+    JSON_Object* data = json_value_get_object(root);
+
+    json_object_set_number(data, "id", this->id);
+    json_object_set_string(data, "snapshot_name", this->snapshotName.c_str());
+
+    return root;
+}
+
+bool CreateCommand::execute(AppState* state, Snapshot* snapshot) {
+    LOG_DEBUG("CreateCommand: execute: Called");
+
+    snapshot->create(this->snapshotName);
+}
+
+unsigned int CreateCommand::getId() {
+    return this->id;
+}
+
+std::string CreateCommand::toString() {
+    std::ostringstream result;
+    result << "CreateCommand: Snapshot '" << this->snapshotName
+           << "' will be created";
+    return result.str();
+}

--- a/src/Commands/DropCommand.cpp
+++ b/src/Commands/DropCommand.cpp
@@ -1,0 +1,83 @@
+/**
+ * DropCommand.cpp
+ *
+ * Copyright (C) 2018 Kano Computing Ltd.
+ * License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+ *
+ * TODO: Description
+ */
+
+
+#include <string>
+#include <sstream>
+
+#include <parson/parson.h>
+
+#include "Commands/CommandFactory.h"
+#include "Commands/DropCommand.h"
+#include "Commands/ICommand.h"
+#include "Logging.h"
+#include "Snapshot.h"
+
+
+DropCommand::DropCommand():
+    DropCommand(1) {
+}
+
+DropCommand::DropCommand(int topMostSnapshots):
+    id(CommandFactory::DROP),
+    topMostSnapshots(topMostSnapshots) {
+
+    if (this->topMostSnapshots < 1) {
+        // TODO: Explode.
+    }
+
+    LOG_DEBUG("DropCommand: constructor called");
+}
+
+DropCommand::~DropCommand() {
+}
+
+bool DropCommand::initialise(JSON_Value* serialisedData) {
+    JSON_Object* jsonObject = json_value_get_object(serialisedData);
+
+    // TODO: Update the Kano libparson to get these:
+    // if (!json_object_has_value_of_type(jsonObject, "id", JSONNumber)) {
+    //     return false;
+    // }
+    // if (json_object_get_number(jsonObject, "id") != ICommand::DROP) {
+    //     return false;
+    // }
+    // if (!json_object_has_value_of_type(jsonObject, "top_most_snapshots", JSONNumber)) {
+    //     return false;
+    // }
+
+    this->topMostSnapshots = json_object_get_number(jsonObject, "top_most_snapshots");
+}
+
+JSON_Value* DropCommand::serialise() {
+    JSON_Value* root = json_value_init_object();
+    JSON_Object* data = json_value_get_object(root);
+
+    json_object_set_number(data, "id", this->id);
+    json_object_set_number(data, "top_most_snapshots", this->topMostSnapshots);
+
+    return root;
+}
+
+bool DropCommand::execute(AppState* state, Snapshot* snapshot) {
+    LOG_DEBUG("DropCommand: execute: Called");
+
+    snapshot->drop(this->topMostSnapshots);
+}
+
+unsigned int DropCommand::getId() {
+    return this->id;
+}
+
+std::string DropCommand::toString() {
+    std::ostringstream result;
+    result << "DropCommand: Top most " << this->topMostSnapshots
+           << " snapshots will be removed";
+    return result.str();
+}

--- a/src/Commands/EnableCommand.cpp
+++ b/src/Commands/EnableCommand.cpp
@@ -1,0 +1,87 @@
+/**
+ * EnableCommand.cpp
+ *
+ * Copyright (C) 2018 Kano Computing Ltd.
+ * License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+ *
+ * TODO: Description
+ */
+
+
+#include <string>
+
+#include <parson/parson.h>
+
+#include "AppState.h"
+#include "Commands/CommandFactory.h"
+#include "Commands/EnableCommand.h"
+#include "Commands/ICommand.h"
+#include "Logging.h"
+#include "Snapshot.h"
+
+
+EnableCommand::EnableCommand():
+    EnableCommand(true) {
+}
+
+EnableCommand::EnableCommand(bool isEnabled):
+    id(CommandFactory::ENABLE),
+    isEnabled(isEnabled) {
+
+    LOG_DEBUG("EnableCommand: constructor called");
+}
+
+EnableCommand::~EnableCommand() {
+}
+
+bool EnableCommand::initialise(JSON_Value* serialisedData) {
+    JSON_Object* jsonObject = json_value_get_object(serialisedData);
+
+    // TODO: Update the Kano libparson to get these:
+    // if (!json_object_has_value_of_type(jsonObject, "id", JSONNumber)) {
+    //     return false;
+    // }
+    // if (json_object_get_number(jsonObject, "id") != ICommand::ENABLE) {
+    //     return false;
+    // }
+    // if (!json_object_has_value_of_type(jsonObject, "is_enabled", JSONBoolean)) {
+    //     return false;
+    // }
+
+    this->isEnabled = json_object_get_boolean(jsonObject, "is_enabled");
+}
+
+JSON_Value* EnableCommand::serialise() {
+    JSON_Value* root = json_value_init_object();
+    JSON_Object* data = json_value_get_object(root);
+
+    json_object_set_number(data, "id", this->id);
+    json_object_set_boolean(data, "is_enabled", this->isEnabled);
+
+    return root;
+}
+
+bool EnableCommand::execute(AppState* state, Snapshot* snapshot) {
+    LOG_DEBUG("EnableCommand: execute: Called");
+
+    if (this->isEnabled) {
+        state->changeState(AppState::ENABLED);
+    } else {
+        state->changeState(AppState::DISABLED);
+    }
+}
+
+unsigned int EnableCommand::getId() {
+    return this->id;
+}
+
+std::string EnableCommand::toString() {
+    std::string result;
+
+    if (this->isEnabled) {
+        result = "EnableCommand: Overlays will be mounted on boot";
+    } else {
+        result = "EnableCommand: Overlays mounting will be disabled";
+    }
+    return result;
+}

--- a/src/Commands/MergeCommand.cpp
+++ b/src/Commands/MergeCommand.cpp
@@ -1,0 +1,82 @@
+/**
+ * MergeCommand.cpp
+ *
+ * Copyright (C) 2018 Kano Computing Ltd.
+ * License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+ *
+ * TODO: Description
+ */
+
+
+#include <string>
+#include <sstream>
+
+#include <parson/parson.h>
+
+#include "Commands/CommandFactory.h"
+#include "Commands/ICommand.h"
+#include "Commands/MergeCommand.h"
+#include "Logging.h"
+#include "Snapshot.h"
+
+
+MergeCommand::MergeCommand():
+    MergeCommand(1) {
+}
+
+MergeCommand::MergeCommand(int topMostSnapshots):
+    id(CommandFactory::MERGE),
+    topMostSnapshots(topMostSnapshots) {
+
+    if (this->topMostSnapshots < 1) {
+        // TODO: Explode.
+    }
+    LOG_DEBUG("MergeCommand: constructor called");
+}
+
+MergeCommand::~MergeCommand() {
+}
+
+bool MergeCommand::initialise(JSON_Value* serialisedData) {
+    JSON_Object* jsonObject = json_value_get_object(serialisedData);
+
+    // TODO: Update the Kano libparson to get these:
+    // if (!json_object_has_value_of_type(jsonObject, "id", JSONNumber)) {
+    //     return false;
+    // }
+    // if (json_object_get_number(jsonObject, "id") != ICommand::MERGE) {
+    //     return false;
+    // }
+    // if (!json_object_has_value_of_type(jsonObject, "top_most_snapshots", JSONNumber)) {
+    //     return false;
+    // }
+
+    this->topMostSnapshots = json_object_get_number(jsonObject, "top_most_snapshots");
+}
+
+JSON_Value* MergeCommand::serialise() {
+    JSON_Value* root = json_value_init_object();
+    JSON_Object* data = json_value_get_object(root);
+
+    json_object_set_number(data, "id", this->id);
+    json_object_set_number(data, "top_most_snapshots", this->topMostSnapshots);
+
+    return root;
+}
+
+bool MergeCommand::execute(AppState* state, Snapshot* snapshot) {
+    LOG_DEBUG("MergeCommand: execute: Called");
+
+    snapshot->merge(this->topMostSnapshots);
+}
+
+unsigned int MergeCommand::getId() {
+    return this->id;
+}
+
+std::string MergeCommand::toString() {
+    std::ostringstream result;
+    result << "MergeCommand: Top most " << this->topMostSnapshots
+           << " snapshots will be merged down";
+    return result.str();
+}

--- a/src/Snapshot.cpp
+++ b/src/Snapshot.cpp
@@ -23,9 +23,10 @@
 #include "Logging.h"
 
 
-Snapshot::Snapshot(JSON_Object* statusLoadedData) {
-    this->statusData = statusLoadedData;
+Snapshot::Snapshot(JSON_Object* statusLoadedData):
+    statusData(statusLoadedData) {
 
+    // TODO: Check if field is not there.
     this->snapshots = json_object_get_array(this->statusData, "snapshots");
 
     if (!createDir(Snapshot::BASE_OVERLAYS_PATH)) {
@@ -190,11 +191,11 @@ void Snapshot::computePaths() {
     }
 
     LOG_DEBUG("Snapshot: computePaths:\n"
-              << "\tlowerDir is: " << getLowerDir() << "\n"
-              << "\tupperDir is: " << getUpperDir() << "\n"
-              << "\tworkDir is: " << getWorkDir() << "\n"
-              << "\tmergedDir is: " << getMergedDir() << "\n"
-              << "\trealDir is: " << getMergedDir() + getRealDir()
+              << "  lowerDir is: " << getLowerDir() << "\n"
+              << "  upperDir is: " << getUpperDir() << "\n"
+              << "  workDir is: " << getWorkDir() << "\n"
+              << "  mergedDir is: " << getMergedDir() << "\n"
+              << "  realDir is: " << getMergedDir() + getRealDir()
     );
 }
 

--- a/src/Status.cpp
+++ b/src/Status.cpp
@@ -18,7 +18,8 @@ Status::Status() {
 }
 
 Status::~Status() {
-    json_value_free(this->data);
+    // TODO: This causes a double free exception?
+    // json_value_free(this->data);
 }
 
 void Status::load() {


### PR DESCRIPTION
Adds the capability to perform multiple operations when rebooting
after scheduling with ovlsnap. Status reporting was updated to
reflect the scheduled commands.

**WARNING:** Not compatible with the previous status file! Remove it
using `sudo rm /boot/ovlsnap_status.json` before upgrading.